### PR TITLE
Changed response status-code for ignored requests to avoid client errors...

### DIFF
--- a/cyclops/handlers/router.py
+++ b/cyclops/handlers/router.py
@@ -31,10 +31,10 @@ class BaseRouterHandler(BaseHandler):
 
             count = self.application.cache.incr(url)
             if count > self.application.config.MAX_CACHE_USES:
-                self.set_status(304)
                 self.set_header("X-CYCLOPS-CACHE-COUNT", str(count))
                 self.set_header("X-CYCLOPS-STATUS", "IGNORED")
                 self.application.ignored_items += 1
+                self.write("IGNORED")
                 self.finish()
                 return count
 
@@ -145,9 +145,9 @@ class BaseRouterHandler(BaseHandler):
             value = randint(1, 100)
 
             if value < int(self.application.config.IGNORE_PERCENTAGE[project_id]):
-                self.set_status(304)
                 self.set_header("X-CYCLOPS-STATUS", "IGNORED")
                 self.application.ignored_items += 1
+                self.write("IGNORED")
                 self.finish()
                 return
 

--- a/tests/handlers/test_router.py
+++ b/tests/handlers/test_router.py
@@ -111,9 +111,9 @@ class BaseRouterTest(AsyncHTTPTestCase):
         expect(response.code).to_equal(200)
         expect(response.body).to_equal("OK")
 
-    def expect_304(self, response):
-        expect(response.code).to_equal(304)
-        expect(response.body).to_be_empty()
+    def expect_200_ignored(self, response):
+        expect(response.code).to_equal(200)
+        expect(response.body).to_equal("IGNORED")
 
     def api_store_url(self, item=None):
         url = "http://ee0c9d854b294d20a2d6d92d0191cac8:0baca85229c74e0f95d52bea5418ddfd@localhost:9000/api/"
@@ -191,7 +191,7 @@ class TestGetRouterHandler(BaseRouterTest):
         for _i in range(self.app.config.MAX_CACHE_USES + 1):
             response = self.fetch('/api/%s/store/?sentry_key=%s' % (item, key))
 
-        self.expect_304(response)
+        self.expect_200_ignored(response)
 
         self.expect_correct_response_headers(response, "IGNORED",
                 expected_cache_count=self.app.config.MAX_CACHE_USES + 1)
@@ -279,7 +279,7 @@ class TestPostRouterHandler(BaseRouterTest):
         for _i in range(self.app.config.MAX_CACHE_USES + 1):
             response = self.fetch('/api/store/', method="POST", headers=headers, body=payload)
 
-        self.expect_304(response)
+        self.expect_200_ignored(response)
         self.expect_correct_response_headers(response, "IGNORED",
                 expected_cache_count=self.app.config.MAX_CACHE_USES + 1)
 


### PR DESCRIPTION
Some clients (like raven-python) treat `304` responses as an error.

I've changed the status-code to `200` to avoid the error and changed the response body to `IGNORED` to differentiate from routed messages.
