### PR TITLE
Add a new option to enable/disable access restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ Here is an example configuration file:
     ## projects handled by this Cyclops instance.
     ## Defaults to: None
     #PROJECT_KEYS = None
+    
+    ## If True, accessing API needs valid PROJECT_KEYS
+    ## Defaults to: True
+    ## RESTRICT_API_ACCESS = True
 
     ################################################################################
 

--- a/cyclops/config.py
+++ b/cyclops/config.py
@@ -23,6 +23,7 @@ Config.define('MAX_REQUESTS_TO_AVERAGE', 5000, 'In order to calculate the averag
 Config.define('IGNORE_PERCENTAGE', {}, 'Use this rate to ignore a percentage of requests if flooded. The keys for this dictionary are the project IDs and the value are the percentage of requests to ignore.', 'Performance')
 
 Config.define('PROJECT_KEYS', None, 'List of (project_id, public_key, secret_key) tuples that describe the projects handled by this Cyclops instance.', 'Projects')
+Config.define('RESTRICT_API_ACCESS', True, 'If True, validate project keys before sending request to Sentry', 'Projects')
 Config.define('MYSQL_HOST', 'localhost', 'Host of your sentry installation MySQL database. Set this to None if you do not wish to load project keys from the database. In that case, you will have to fill the PROJECT_KEYS variable.', 'Database')
 Config.define('MYSQL_PORT', 3306, 'Port of your sentry installation MySQL database.', 'Database')
 Config.define('MYSQL_DB', 'sentry', 'Database of your sentry installation MySQL database.', 'Database')


### PR DESCRIPTION
Summary: Cyclops does some checks on API access based on project keys. One might want to ignore these checks and let sentry itself decide about permitting requests or not.

Test Plan: Set `RESTRICT_API_ACCESS = True` in config file, and send some requests. You should not get 403/404 errors.