### PR TITLE
Add postgres and sqlite support

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,27 +144,30 @@ Here is an example configuration file:
 
     ################################### Database ###################################
 
-    ## Host of your sentry installation MySQL database. Set this to None if you do
+    ## Database backend (either "mysql", "postgres" or "sqlite").
+    #DB_BACKEND = 'mysql'
+
+    ## Host of your sentry installation database. Set this to None if you do
     ## not wish to load project keys from the database. In that case, you will
     ## have to fill the PROJECT_KEYS variable.
     ## Defaults to: localhost
-    #MYSQL_HOST = 'localhost'
+    #DB_HOST = 'localhost'
 
     ## Port of your sentry installation MySQL database.
     ## Defaults to: 3306
-    #MYSQL_PORT = 3306
+    #DB_PORT = 3306
 
-    ## Database of your sentry installation MySQL database.
+    ## Name of your sentry installation MySQL database.
     ## Defaults to: sentry
-    #MYSQL_DB = 'sentry'
+    #DB_NAME = 'sentry'
 
     ## User of your sentry installation MySQL database.
     ## Defaults to: root
-    #MYSQL_USER = 'root'
+    #DB_USER = 'root'
 
     ## Password of your sentry installation MySQL database.
     ## Defaults to: 
-    #MYSQL_PASS = ''
+    #DB_PASS = ''
 
     ################################################################################
 

--- a/cyclops/config.py
+++ b/cyclops/config.py
@@ -24,11 +24,20 @@ Config.define('IGNORE_PERCENTAGE', {}, 'Use this rate to ignore a percentage of 
 
 Config.define('PROJECT_KEYS', None, 'List of (project_id, public_key, secret_key) tuples that describe the projects handled by this Cyclops instance.', 'Projects')
 Config.define('RESTRICT_API_ACCESS', True, 'If True, validate project keys before sending request to Sentry', 'Projects')
-Config.define('MYSQL_HOST', 'localhost', 'Host of your sentry installation MySQL database. Set this to None if you do not wish to load project keys from the database. In that case, you will have to fill the PROJECT_KEYS variable.', 'Database')
-Config.define('MYSQL_PORT', 3306, 'Port of your sentry installation MySQL database.', 'Database')
-Config.define('MYSQL_DB', 'sentry', 'Database of your sentry installation MySQL database.', 'Database')
-Config.define('MYSQL_USER', 'root', 'User of your sentry installation MySQL database.', 'Database')
-Config.define('MYSQL_PASS', '', 'Password of your sentry installation MySQL database.', 'Database')
+
+Config.define('DB_BACKEND', 'mysql', 'Database backend (either "mysql", "postgres" or "sqlite").')
+Config.define('DB_HOST', 'localhost', 'Host of your sentry installation MySQL database. Set this to None if you do not wish to load project keys from the database. In that case, you will have to fill the PROJECT_KEYS variable.', 'Database')
+Config.define('DB_PORT', 3306, 'Port of your sentry installation MySQL database.', 'Database')
+Config.define('DB_NAME', 'sentry', 'Name of your sentry installation MySQL database.', 'Database')
+Config.define('DB_USER', 'root', 'User of your sentry installation MySQL database.', 'Database')
+Config.define('DB_PASS', '', 'Password of your sentry installation MySQL database.', 'Database')
+
+# Deprecated names
+Config.alias('MYSQL_HOST', 'DB_HOST')
+Config.alias('MYSQL_PORT', 'DB_PORT')
+Config.alias('MYSQL_DB', 'DB_NAME')
+Config.alias('MYSQL_USER', 'DB_USER')
+Config.alias('MYSQL_PASS', 'DB_PASS')
 
 Config.define('URL_CACHE_EXPIRATION', 1, 'The amount of seconds to cache a given URL of error. This is meant to be a way to avoid flooding your sentry farm with repeated errors. Set to 0 if you don\'t want to cache any errors.', 'Cache')
 Config.define('MAX_CACHE_USES', 10, 'Number of requests to accept in the specified expiration of the cache per url.', 'Cache')

--- a/cyclops/db.py
+++ b/cyclops/db.py
@@ -1,0 +1,55 @@
+from contextlib import contextmanager
+
+
+def _dict_factory(cursor, row):
+    d = {}
+    for idx,col in enumerate(cursor.description):
+        d[col[0]] = row[idx]
+    return d
+
+
+@contextmanager
+def _connection(config):
+    conn = None
+    try:
+        if config.DB_BACKEND == 'mysql':
+            from torndb import Connection
+            conn = Connection(
+                "%s:%s" % (config.DB_HOST, config.DB_PORT),
+                config.DB_NAME,
+                user=config.DB_USER,
+                password=config.DB_PASS
+            )
+        elif config.DB_BACKEND == 'sqlite':
+            import sqlite3
+            conn = sqlite3.connect(config.DB_NAME)
+            conn.row_factory = _dict_factory
+        elif config.DB_BACKEND == 'postgres':
+            import psycopg2
+            from psycopg2.extras import DictConnection
+
+            conn = psycopg2.connect(
+                database=config.DB_NAME,
+                user=config.DB_USER,
+                password=config.DB_PASS,
+                host=config.DB_HOST,
+                port=config.DB_PORT,
+                connection_factory=DictConnection,
+            )
+        else:
+            raise ValueError("Unknown backend %r" % config.DB_BACKEND)
+
+        yield conn
+    finally:
+        if conn is not None:
+            conn.close()
+
+
+def query(query, config):
+    with _connection(config) as conn:
+        if config.DB_BACKEND == 'mysql':
+            return conn.query(query)
+        else:
+            cur = conn.cursor()
+            cur.execute(query)
+            return list(cur.fetchall())

--- a/setup.py
+++ b/setup.py
@@ -47,13 +47,16 @@ It keeps items in memory and dumps them at sentry in regular intervals.
     extras_require={
         'tests': tests_require,
         'mysql': mysql_requires,
+        'postgres': [
+            'psycopg2',
+        ],
     },
 
     install_requires=[
         'tornado>=3.0.0',
         'derpconf==0.3.3',
         'pycurl==7.19.0',
-        'requests==1.1.0',
+        'requests',
         'ujson==1.30',
         'msgpack-python==0.3.0',
         'redis==2.7.2',

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -71,6 +71,6 @@ def forget():
 def get_config(*args, **kw):
     if not kw:
         kw = {}
-    kw['MYSQL_DB'] = 'sentry_tests'
+    kw['DB_NAME'] = 'sentry_tests'
 
     return Config(**kw)

--- a/tests/test.conf
+++ b/tests/test.conf
@@ -71,27 +71,29 @@ PROJECT_KEYS = None
 
 ################################### Database ###################################
 
-## Host of your sentry installation MySQL database. Set this to None if you do
+DB_BACKEND = 'mysql'
+
+## Host of your sentry installation database. Set this to None if you do
 ## not wish to load project keys from the database. In that case, you will
 ## have to fill the PROJECT_KEYS variable.
 ## Defaults to: localhost
-MYSQL_HOST = 'localhost'
+DB_HOST = 'localhost'
 
-## Port of your sentry installation MySQL database.
+## Port of your sentry installation database.
 ## Defaults to: 3306
-MYSQL_PORT = 3306
+DB_PORT = 3306
 
-## Database of your sentry installation MySQL database.
+## Name of your sentry installation database.
 ## Defaults to: sentry
-MYSQL_DB = 'sentry'
+DB_NAME = 'sentry'
 
-## User of your sentry installation MySQL database.
+## User of your sentry installation database.
 ## Defaults to: root
-MYSQL_USER = 'root'
+DB_USER = 'root'
 
-## Password of your sentry installation MySQL database.
-## Defaults to: 
-MYSQL_PASS = ''
+## Password of your sentry installation database.
+## Defaults to:
+DB_PASS = ''
 
 ################################################################################
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -6,14 +6,14 @@ from preggy import expect
 from cyclops.config import Config
 from cyclops.projects import ProjectLoader
 
-def test_project_keys_without_mysql():
+def test_project_keys_without_db():
     config = Config()
     config.PROJECT_KEYS = [
         (1, "public1", "secret1"),
         (2, "public2", "secret2"),
         (1, "public1.2", "secret1.2"),
     ]
-    config.MYSQL_HOST = None
+    config.DB_HOST = None
     project_loader = ProjectLoader(config)
     project_keys = project_loader.get_project_keys()
     expect(project_keys).to_equal({


### PR DESCRIPTION
Adds support for postgres and sqlite db backends.

The `MYSQL_` settings still work but have been deprecated in favour of `DB_`.

A new setting `DB_BACKEND` has been introduced.

This also removes the need for requests 1.1, since newer versions work fine and that seemed unnecessary.

Postgres users will need psycopg2, but they probably already have that. sqlite3 is included in the stdlib.